### PR TITLE
FCFIELDS-19: RMB 33.1.1, Vert.x 4.1.4, folio-service-tools 1.7.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.6.1
+* FCFIELDS-19 Upgrade to RMB 33.1.1, Vert.x 4.1.4, folio-service-tools 1.7.1
+
 ## 1.6.0 2021-06-09
 * FCFIELDS-17 Upgrade to RMB 33 and Vert.X 4.1.0.CR1
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,15 +15,15 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
-    <folio-service-tools.version>1.7.0</folio-service-tools.version>
-    <folio-di-support.version>1.4.0</folio-di-support.version>
-    <lombok.version>1.18.12</lombok.version>
+    <raml-module-builder.version>33.1.1</raml-module-builder.version>
+    <folio-service-tools.version>1.7.1</folio-service-tools.version>
+    <folio-di-support.version>1.4.1</folio-di-support.version>
+    <lombok.version>1.18.20</lombok.version>
     <commons-validator.version>1.7</commons-validator.version>
-    <junit.version>4.13.1</junit.version>
-    <spring.version>5.2.8.RELEASE</spring.version>
-    <easy-random.version>4.2.0</easy-random.version>
-    <rest-assured.version>4.3.1</rest-assured.version>
+    <junit.version>4.13.2</junit.version>
+    <spring.version>5.2.17.RELEASE</spring.version>
+    <easy-random.version>4.3.0</easy-random.version>
+    <rest-assured.version>4.4.0</rest-assured.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
Also upgrade all other dependencies.

Needed for https://issues.folio.org/browse/MODUSERS-272 because Vert.x 1.4.1 changed Context.getLocal(String) to Context.getLocal(Object), see https://issues.folio.org/browse/RMB-874