### PR TITLE
FCFIELDS-20: Release for R3 2021

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 1.6.1
+## 1.6.1 2021-10-04
 * FCFIELDS-19 Upgrade to RMB 33.1.1, Vert.x 4.1.4, folio-service-tools 1.7.1
 
 ## 1.6.0 2021-06-09

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>folio-custom-fields</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.6.1</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -390,7 +390,7 @@
     <url>https://github.com/folio-org/folio-custom-fields</url>
     <connection>scm:git:git://github.com/folio-org/folio-custom-fields</connection>
     <developerConnection>scm:git:git@github.com:folio-org/folio-custom-fields.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.6.1</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>folio-custom-fields</artifactId>
-  <version>1.6.1</version>
+  <version>1.7.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -390,7 +390,7 @@
     <url>https://github.com/folio-org/folio-custom-fields</url>
     <connection>scm:git:git://github.com/folio-org/folio-custom-fields</connection>
     <developerConnection>scm:git:git@github.com:folio-org/folio-custom-fields.git</developerConnection>
-    <tag>v1.6.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
Comes with these R3 2021 versions:
* RMB 33.1.1
* Vert.x 4.1.4
* folio-service-tools 1.7.1