### PR TITLE
FOLIO-3231 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,9 @@ buildMvn {
   publishModDescriptor = false
   mvnDeploy = true
   publishAPI = true
-  runLintRamlCop = true
   buildNode = 'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 buildMvn {
   publishModDescriptor = false
   mvnDeploy = true
-  publishAPI = true
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # folio-custom-fields
 
-Copyright (C) 2019-2020 The Open Library Foundation
+Copyright (C) 2019-2021 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/ramls/examples/customFieldOptionStatistic.sample
+++ b/ramls/examples/customFieldOptionStatistic.sample
@@ -1,5 +1,5 @@
 {
-  "optionId": "opt_1"
+  "optionId": "opt_1",
   "customFieldId": "a772e255-4f75-4742-8735-a8b1a02348d4",
   "entityType": "package",
   "count": 10


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/

The https://dev.folio.org/reference/api/#folio-custom-fields section of API documentation will be automatically reconfigured tomorrow:
https://dev.folio.org/reference/api/#explain-gather-config
