### PR TITLE
FCFIELDS-23 Upgrade to RAML Module Builder 33.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <lombok.version>1.18.20</lombok.version>
     <commons-validator.version>1.7</commons-validator.version>
     <junit.version>4.13.2</junit.version>
-    <spring.version>5.2.17.RELEASE</spring.version>
+    <spring.version>5.3.14</spring.version>
     <easy-random.version>4.3.0</easy-random.version>
     <rest-assured.version>4.4.0</rest-assured.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.1.1</raml-module-builder.version>
-    <folio-service-tools.version>1.7.1</folio-service-tools.version>
-    <folio-di-support.version>1.4.1</folio-di-support.version>
+    <raml-module-builder.version>33.2.4</raml-module-builder.version>
+    <folio-service-tools.version>1.8.0-SNAPSHOT</folio-service-tools.version>
+    <folio-di-support.version>1.5.0-SNAPSHOT</folio-di-support.version>
     <lombok.version>1.18.20</lombok.version>
     <commons-validator.version>1.7</commons-validator.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
Update to the latest RMB 33.2.* release.

See details: https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md
