### PR TITLE
[FCFIELDS-43] - Attribute helpText of customField cannot be null

### DIFF
--- a/src/main/java/org/folio/validate/definition/HelpTextValidator.java
+++ b/src/main/java/org/folio/validate/definition/HelpTextValidator.java
@@ -1,10 +1,11 @@
 package org.folio.validate.definition;
 
+import java.util.Objects;
+
 import org.apache.commons.lang3.Validate;
+import org.folio.rest.jaxrs.model.CustomField;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import org.folio.rest.jaxrs.model.CustomField;
 
 @Component
 public class HelpTextValidator  implements Validatable {
@@ -19,8 +20,10 @@ public class HelpTextValidator  implements Validatable {
    */
   @Override
   public void validateDefinition(CustomField fieldDefinition) {
-    Validate.isTrue(fieldDefinition.getHelpText().length() <= helpTextLengthLimit,
-      "The 'helpText' length cannot be more than %s", helpTextLengthLimit);
+    if(!Objects.isNull(fieldDefinition.getHelpText())) {
+      Validate.isTrue(fieldDefinition.getHelpText().length() <= helpTextLengthLimit,
+        "The 'helpText' length cannot be more than %s", helpTextLengthLimit);
+    }
   }
 
   @Override

--- a/src/test/java/org/folio/validate/definition/HelpTextValidatorTest.java
+++ b/src/test/java/org/folio/validate/definition/HelpTextValidatorTest.java
@@ -3,6 +3,10 @@ package org.folio.validate.definition;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.spring.TestConfiguration;
+import org.folio.test.util.TestUtil;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -10,10 +14,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import org.folio.rest.jaxrs.model.CustomField;
-import org.folio.spring.TestConfiguration;
-import org.folio.test.util.TestUtil;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = TestConfiguration.class)
@@ -30,6 +30,14 @@ public class HelpTextValidatorTest {
     expectedEx.expectMessage("The 'helpText' length cannot be more than 100");
     final CustomField customField = TestUtil.readJsonFile(
       "fields/post/postCustomFieldHelpTextInvalid.json", CustomField.class);
+    validator.validateDefinition(customField);
+  }
+
+  @Test
+  public void shouldPassValidationForHelpTextWithNull() throws IOException, URISyntaxException {
+    Assert.assertFalse(expectedEx.isAnyExceptionExpected());
+    final CustomField customField = TestUtil.readJsonFile(
+      "fields/post/postCustomFieldHelpTextNull.json", CustomField.class);
     validator.validateDefinition(customField);
   }
 }

--- a/src/test/resources/fields/post/postCustomFieldHelpTextNull.json
+++ b/src/test/resources/fields/post/postCustomFieldHelpTextNull.json
@@ -1,0 +1,8 @@
+{
+  "name": "test custom field",
+  "visible": true,
+  "required": true,
+  "type": "RADIO_BUTTON",
+  "entityType": "user",
+  "order": 1
+}


### PR DESCRIPTION
## Purpose
_Describe the purpose of the pull request. Include background information if necessary._
The purpose of this PR is to fix the issue present in FCFIELDS-43
## Approach
_How does this change fulfill the purpose?_
As of now the Help Text field was considered to be mandatory although its not marked as required. The length validation on help text field should not be mandate. Add an extra check before checking for the length validation.
### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
