### PR TITLE
Revert "[FCFIELDS-43] - Attribute helpText of customField cannot be null"

### DIFF
--- a/src/main/java/org/folio/validate/definition/HelpTextValidator.java
+++ b/src/main/java/org/folio/validate/definition/HelpTextValidator.java
@@ -1,11 +1,10 @@
 package org.folio.validate.definition;
 
-import java.util.Objects;
-
 import org.apache.commons.lang3.Validate;
-import org.folio.rest.jaxrs.model.CustomField;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import org.folio.rest.jaxrs.model.CustomField;
 
 @Component
 public class HelpTextValidator  implements Validatable {
@@ -20,10 +19,8 @@ public class HelpTextValidator  implements Validatable {
    */
   @Override
   public void validateDefinition(CustomField fieldDefinition) {
-    if(!Objects.isNull(fieldDefinition.getHelpText())) {
-      Validate.isTrue(fieldDefinition.getHelpText().length() <= helpTextLengthLimit,
-        "The 'helpText' length cannot be more than %s", helpTextLengthLimit);
-    }
+    Validate.isTrue(fieldDefinition.getHelpText().length() <= helpTextLengthLimit,
+      "The 'helpText' length cannot be more than %s", helpTextLengthLimit);
   }
 
   @Override

--- a/src/test/java/org/folio/validate/definition/HelpTextValidatorTest.java
+++ b/src/test/java/org/folio/validate/definition/HelpTextValidatorTest.java
@@ -3,10 +3,6 @@ package org.folio.validate.definition;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import org.folio.rest.jaxrs.model.CustomField;
-import org.folio.spring.TestConfiguration;
-import org.folio.test.util.TestUtil;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -14,6 +10,10 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.spring.TestConfiguration;
+import org.folio.test.util.TestUtil;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = TestConfiguration.class)
@@ -30,14 +30,6 @@ public class HelpTextValidatorTest {
     expectedEx.expectMessage("The 'helpText' length cannot be more than 100");
     final CustomField customField = TestUtil.readJsonFile(
       "fields/post/postCustomFieldHelpTextInvalid.json", CustomField.class);
-    validator.validateDefinition(customField);
-  }
-
-  @Test
-  public void shouldPassValidationForHelpTextWithNull() throws IOException, URISyntaxException {
-    Assert.assertFalse(expectedEx.isAnyExceptionExpected());
-    final CustomField customField = TestUtil.readJsonFile(
-      "fields/post/postCustomFieldHelpTextNull.json", CustomField.class);
     validator.validateDefinition(customField);
   }
 }

--- a/src/test/resources/fields/post/postCustomFieldHelpTextNull.json
+++ b/src/test/resources/fields/post/postCustomFieldHelpTextNull.json
@@ -1,8 +1,0 @@
-{
-  "name": "test custom field",
-  "visible": true,
-  "required": true,
-  "type": "RADIO_BUTTON",
-  "entityType": "user",
-  "order": 1
-}


### PR DESCRIPTION
Reverts folio-org/folio-custom-fields#39

Reverting it as some UI effects noticed. Will merge the PR after that is fixed.