### PR TITLE
[FCFIELDS-44] - PUT /custom-fields does not handle multiple entity types

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,7 +5,7 @@
   "provides": [
     {
       "id": "custom-fields",
-      "version": "2.1",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>folio-custom-fields</artifactId>
-  <version>1.10.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>

--- a/ramls/putCustomFieldCollection.json
+++ b/ramls/putCustomFieldCollection.json
@@ -12,6 +12,10 @@
         "$ref": "customField.json"
       }
     },
+    "entityType": {
+      "type": "string",
+      "description": "The entityType of custom fields"
+    },
     "metadata": {
       "description": "User metadata information",
       "$ref": "raml-util/schemas/metadata.schema",
@@ -19,6 +23,7 @@
     }
   },
   "required": [
-    "customFields"
+    "customFields",
+    "entityType"
   ]
 }

--- a/src/main/java/org/folio/rest/impl/CustomFieldsImpl.java
+++ b/src/main/java/org/folio/rest/impl/CustomFieldsImpl.java
@@ -62,6 +62,7 @@ public class CustomFieldsImpl implements CustomFields {
   @HandleValidationErrors
   public void putCustomFields(String xOkapiModuleId, PutCustomFieldCollection request, Map<String, String> okapiHeaders,
                               Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    validatePutCustomFieldCollection(request);
     List<CustomField> customFields = request.getCustomFields();
     customFields
       .forEach(definitionValidator::validate);
@@ -138,5 +139,27 @@ public class CustomFieldsImpl implements CustomFields {
     respond(optionStatResult,
       GetCustomFieldsOptionsStatsByIdAndOptIdResponse::respond200WithApplicationJson,
       asyncResultHandler, excHandler);
+  }
+
+  private void validatePutCustomFieldCollection(PutCustomFieldCollection customFieldCollection)
+    throws IllegalArgumentException {
+    List<String> entityTypes =
+        customFieldCollection.getCustomFields().stream()
+            .map(CustomField::getEntityType)
+            .distinct()
+            .toList();
+    if (entityTypes.size() > 1) {
+      throw new IllegalArgumentException(
+          String.format("Multiple entityTypes found: %s", entityTypes));
+    }
+    if (!entityTypes.isEmpty()) {
+      String entityType = entityTypes.get(0);
+      if (!entityType.equals(customFieldCollection.getEntityType())) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Collection entityType '%s' does not match custom fields entityType '%s'",
+                customFieldCollection.getEntityType(), entityType));
+      }
+    }
   }
 }

--- a/src/main/java/org/folio/rest/impl/CustomFieldsImpl.java
+++ b/src/main/java/org/folio/rest/impl/CustomFieldsImpl.java
@@ -66,7 +66,7 @@ public class CustomFieldsImpl implements CustomFields {
     customFields
       .forEach(definitionValidator::validate);
     customFields.forEach(field -> field.setMetadata(request.getMetadata()));
-    Future<CustomFieldCollection> updatedFields = customFieldsService.replaceAll(customFields, new OkapiParams(okapiHeaders))
+    Future<CustomFieldCollection> updatedFields = customFieldsService.replaceAll(customFields, request.getEntityType(), new OkapiParams(okapiHeaders))
       .map(fields -> new CustomFieldCollection()
         .withCustomFields(fields)
         .withTotalRecords(fields.size()));

--- a/src/main/java/org/folio/service/CustomFieldsService.java
+++ b/src/main/java/org/folio/service/CustomFieldsService.java
@@ -57,16 +57,17 @@ public interface CustomFieldsService {
   Future<Void> delete(String id, String tenantId);
 
   /**
-   * Replaces all existing custom fields with new collection of custom fields.
-   * If new collection has fields with ids that already exist then those fields will be updated,
-   * fields with ids that don't exist will be added,
-   * existing fields that are not present in new collection will be deleted
+   * Replaces all existing custom fields with new collection of custom fields. If new collection has
+   * fields with ids that already exist then those fields will be updated, fields with ids that
+   * don't exist will be added, existing fields that are not present in new collection will be
+   * deleted. Only custom fields with the specified entityType will be affected.
    *
    * @param newFields collection of new custom fields
-   * @param params    OkapiParams
+   * @param entityType entityType of custom fields
+   * @param params OkapiParams
    * @return updated collection of custom fields
    */
-  Future<List<CustomField>> replaceAll(List<CustomField> newFields, OkapiParams params);
+  Future<List<CustomField>> replaceAll(List<CustomField> newFields, String entityType, OkapiParams params);
 
   /**
    * Retrieves statistic of specific custom field definition usage.

--- a/src/main/java/org/folio/service/CustomFieldsServiceImpl.java
+++ b/src/main/java/org/folio/service/CustomFieldsServiceImpl.java
@@ -146,10 +146,12 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
   }
 
   @Override
-  public Future<List<CustomField>> replaceAll(List<CustomField> customFields, OkapiParams params) {
+  public Future<List<CustomField>> replaceAll(
+      List<CustomField> customFields, String entityType, OkapiParams params) {
     log.debug("replaceAll:: Attempt to replace all customFields by [tenantId: {}]", params.getTenant());
 
-    return repository.findByQuery(null, 0, Integer.MAX_VALUE, params.getTenant())
+    String queryStr = String.format("query=(entityType==%s)", entityType);
+    return repository.findByQuery(queryStr, 0, Integer.MAX_VALUE, params.getTenant())
       .compose(existingFields -> {
         setOrder(customFields);
         setIdIfEmpty(customFields);

--- a/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
@@ -423,6 +423,35 @@ public class CustomFieldsImplTest extends TestBase {
   }
 
   @Test
+  public void putCustomFieldsShouldReturn422OnMultipleEntityTypes()
+      throws IOException, URISyntaxException {
+    PutCustomFieldCollection request =
+        readJsonFile("fields/put/putCustomFieldCollection.json", PutCustomFieldCollection.class);
+    request.getCustomFields().get(0).setEntityType("other");
+    String error =
+        putWithStatus(
+                CUSTOM_FIELDS_PATH, Json.encode(request), SC_UNPROCESSABLE_ENTITY, USER1_HEADER)
+            .asString();
+    assertThat(error, containsString("Multiple entityTypes found"));
+  }
+
+  @Test
+  public void putCustomFieldsShouldReturn422WhenCollectionEntityTypeDiffers()
+      throws IOException, URISyntaxException {
+    PutCustomFieldCollection request =
+        readJsonFile("fields/put/putCustomFieldCollection.json", PutCustomFieldCollection.class);
+    request.setEntityType("other");
+    String error =
+        putWithStatus(
+                CUSTOM_FIELDS_PATH, Json.encode(request), SC_UNPROCESSABLE_ENTITY, USER1_HEADER)
+            .asString();
+    assertThat(
+        error,
+        containsString(
+            "Collection entityType 'other' does not match custom fields entityType 'user'"));
+  }
+
+  @Test
   public void shouldReturn422WhenFieldFormatIsNullOnPut() throws IOException, URISyntaxException {
     CustomField field = readJsonFile("fields/post/textbox/postTextBoxShort.json", CustomField.class);
     String postBody = Json.encode(field);

--- a/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
@@ -223,7 +223,7 @@ public class CustomFieldsImplTest extends TestBase {
 
   @Test
   public void shouldReturnAllFieldsOnGetSortedByOrder() throws IOException, URISyntaxException {
-    createFields();
+    createFieldsMultipleEntityTypes();
     CustomFieldCollection fields = getWithOk(CUSTOM_FIELDS_PATH).as(CustomFieldCollection.class);
     assertEquals(2, fields.getCustomFields().size());
     assertThat(fields.getCustomFields().get(0), is(allOf(
@@ -242,7 +242,7 @@ public class CustomFieldsImplTest extends TestBase {
 
   @Test
   public void shouldReturnFieldsByName() throws IOException, URISyntaxException {
-    createFields();
+    createFieldsMultipleEntityTypes();
     String resourcePath = CUSTOM_FIELDS_PATH + "?query=name==Department";
     CustomFieldCollection fields = getWithOk(resourcePath).as(CustomFieldCollection.class);
     assertEquals(1, fields.getCustomFields().size());
@@ -254,7 +254,7 @@ public class CustomFieldsImplTest extends TestBase {
 
   @Test
   public void shouldReturnFieldsByEntityType() throws IOException, URISyntaxException {
-    createFields();
+    createFieldsMultipleEntityTypes();
     String resourcePath = CUSTOM_FIELDS_PATH + "?query=entityType==package";
     CustomFieldCollection fields = getWithOk(resourcePath).as(CustomFieldCollection.class);
     assertEquals(1, fields.getCustomFields().size());
@@ -265,7 +265,7 @@ public class CustomFieldsImplTest extends TestBase {
 
   @Test
   public void shouldReturnFieldsWithPagination() throws IOException, URISyntaxException {
-    createFields();
+    createFieldsMultipleEntityTypes();
     String resourcePath = CUSTOM_FIELDS_PATH + "?offset=0&limit=1&query=cql.allRecords=1 sortby name";
     CustomFieldCollection fields = getWithOk(resourcePath).as(CustomFieldCollection.class);
     assertEquals(1, fields.getCustomFields().size());
@@ -687,9 +687,9 @@ public class CustomFieldsImplTest extends TestBase {
     assertThat(error, containsString("CustomField not found by id"));
   }
 
-  private void createFields() throws IOException, URISyntaxException {
+  private void createFieldsMultipleEntityTypes() throws IOException, URISyntaxException {
     createCustomField(readFile("fields/post/postCustomField.json"));
-    createCustomField(readFile("fields/post/postCustomField2.json"));
+    createCustomField(readFile("fields/post/postCustomField-package.json"));
   }
 
   private CustomField createCustomField(String postBody) {

--- a/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
@@ -47,6 +47,7 @@ import org.folio.rest.jaxrs.model.CustomFieldOptionStatistic;
 import org.folio.rest.jaxrs.model.CustomFieldStatistic;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Metadata;
+import org.folio.rest.jaxrs.model.PutCustomFieldCollection;
 import org.folio.rest.jaxrs.model.TextField;
 import org.folio.test.util.TestBase;
 import org.junit.Before;
@@ -434,7 +435,7 @@ public class CustomFieldsImplTest extends TestBase {
     assertEquals(1, (int) firstField.getOrder());
     assertEquals(2, (int) secondField.getOrder());
 
-    CustomFieldCollection request = readJsonFile("fields/put/putCustomFieldCollection.json", CustomFieldCollection.class);
+    PutCustomFieldCollection request = readJsonFile("fields/put/putCustomFieldCollection.json", PutCustomFieldCollection.class);
     request.getCustomFields().get(1).setId(field1.getId());
     putWithNoContent(CUSTOM_FIELDS_PATH, Json.encode(request), USER2_HEADER);
 
@@ -490,7 +491,7 @@ public class CustomFieldsImplTest extends TestBase {
     final String cfNameUpdated = "Expiration Date updated";
     field2.setName(cfNameUpdated);
     field3.setRefId("some-ref-id_1");
-    CustomFieldCollection request = new CustomFieldCollection().withCustomFields(Arrays.asList(field3, field2));
+    PutCustomFieldCollection request = new PutCustomFieldCollection().withCustomFields(Arrays.asList(field3, field2)).withEntityType("user");
     putWithNoContent(CUSTOM_FIELDS_PATH, Json.encode(request), USER2_HEADER);
 
     List<CustomField> customFieldsAfterUpdate = getAllCustomFields(vertx);
@@ -523,7 +524,7 @@ public class CustomFieldsImplTest extends TestBase {
     //update cf id
     field2.setId(null);
 
-    CustomFieldCollection request = new CustomFieldCollection().withCustomFields(Arrays.asList(field1, field2));
+    PutCustomFieldCollection request = new PutCustomFieldCollection().withCustomFields(Arrays.asList(field1, field2)).withEntityType("user");
     putWithNoContent(CUSTOM_FIELDS_PATH, Json.encode(request), USER2_HEADER);
 
     List<CustomField> customFieldsAfterUpdate = getAllCustomFields(vertx);
@@ -551,7 +552,7 @@ public class CustomFieldsImplTest extends TestBase {
     //update cf type
     field2.setType(CustomField.Type.TEXTBOX_LONG);
 
-    CustomFieldCollection request = new CustomFieldCollection().withCustomFields(Arrays.asList(field1, field2));
+    PutCustomFieldCollection request = new PutCustomFieldCollection().withCustomFields(Arrays.asList(field1, field2)).withEntityType("user");
     String error = putWithStatus(CUSTOM_FIELDS_PATH, Json.encode(request), SC_UNPROCESSABLE_ENTITY, USER2_HEADER).asString();
     assertThat(error, containsString("The type of the custom field can not be changed"));
   }

--- a/src/test/resources/fields/post/postCustomField-package.json
+++ b/src/test/resources/fields/post/postCustomField-package.json
@@ -4,7 +4,7 @@
   "refId": "not-null-ref-id",
   "visible": true,
   "required": true,
-  "entityType": "user",
+  "entityType": "package",
   "helpText": "Set expiration date",
   "order": 1
 }

--- a/src/test/resources/fields/put/putCustomFieldCollection.json
+++ b/src/test/resources/fields/put/putCustomFieldCollection.json
@@ -5,7 +5,7 @@
       "type" : "TEXTBOX_SHORT",
       "visible": true,
       "required": true,
-      "entityType": "package",
+      "entityType": "user",
       "helpText": "Set new expiration date"
     },
     {

--- a/src/test/resources/fields/put/putCustomFieldCollection.json
+++ b/src/test/resources/fields/put/putCustomFieldCollection.json
@@ -20,5 +20,6 @@
         "default": true
       }
     }
-  ]
+  ],
+  "entityType": "user"
 }


### PR DESCRIPTION
## Purpose
This PR resolves the issue [FCFIELDS-44](https://issues.folio.org/browse/FCFIELDS-44) where the `PUT /custom-fields` endpoint was unable to handle different `entityType`s.

## Approach
To address this issue, a required attribute called `entityType` has been added to the `PutCustomFieldCollection` schema. This change mandates clients to include the `entityType` when updating custom fields using the PUT /custom-fields endpoint. With this addition, the implementation can now update custom fields specifically for a certain `entityType` without affecting others.

### TODOs and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.

## Additional Actions
This is a **breaking change**. Client implementations will require adjustments to include the `entityType` when making `PUT` requests to `/custom-fields`.
- Should be merged together with [STSMACOM PR#1417](https://github.com/folio-org/stripes-smart-components/pull/1417)
