### PR TITLE
[FCFIELDS-48] Update RecordUpdate to contain CustomField object

### DIFF
--- a/src/main/java/org/folio/model/RecordUpdate.java
+++ b/src/main/java/org/folio/model/RecordUpdate.java
@@ -1,13 +1,23 @@
 package org.folio.model;
 
 import java.util.List;
-
+import lombok.NonNull;
 import lombok.Value;
+import org.folio.rest.jaxrs.model.CustomField;
 
 @Value
 public class RecordUpdate {
 
-  String refId;
-  List<String> optionIdsToDelete;
-  List<String> defaultIds;
+  @NonNull CustomField customField;
+  @NonNull List<String> optionIdsToDelete;
+  @NonNull List<String> defaultIds;
+
+  /**
+   * Method returns refId from customField. Added for compatibility with previous version.
+   *
+   * @return refId
+   */
+  public String getRefId() {
+    return customField.getRefId();
+  }
 }

--- a/src/main/java/org/folio/service/CustomFieldsServiceImpl.java
+++ b/src/main/java/org/folio/service/CustomFieldsServiceImpl.java
@@ -293,7 +293,7 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
       generateOptionIds(customField);
       List<String> optionIdsToDelete = getOptionsIdsToDelete(customField, oldCustomField);
       List<String> defaultIds = extractDefaultOptionIds(customField);
-      recordUpdate = new RecordUpdate(customField.getRefId(), optionIdsToDelete, defaultIds);
+      recordUpdate = new RecordUpdate(customField, optionIdsToDelete, defaultIds);
     }
     return recordUpdate;
   }

--- a/src/test/java/org/folio/model/RecordUpdateTest.java
+++ b/src/test/java/org/folio/model/RecordUpdateTest.java
@@ -1,0 +1,16 @@
+package org.folio.model;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.junit.Test;
+
+public class RecordUpdateTest {
+
+  @Test
+  public void testGetRefId() {
+    RecordUpdate recordUpdate = new RecordUpdate(new CustomField().withRefId("textbox"), emptyList(), emptyList());
+    assertEquals("textbox", recordUpdate.getRefId());
+  }
+}

--- a/src/test/java/org/folio/service/NoOpRecordServiceTest.java
+++ b/src/test/java/org/folio/service/NoOpRecordServiceTest.java
@@ -102,7 +102,7 @@ public class NoOpRecordServiceTest {
 
   @Test
   public void shouldReturnSuccessOnDeleteMissedOptionValues() {
-    RecordUpdate recordUpdate = new RecordUpdate(field.getRefId(), Collections.emptyList(), Collections.emptyList());
+    RecordUpdate recordUpdate = new RecordUpdate(field, Collections.emptyList(), Collections.emptyList());
     Future<Void> res = service.deleteMissedOptionValues(recordUpdate, tenantId);
 
     assertNotNull(res);


### PR DESCRIPTION
## Purpose
This PR expands the `RecordUpdate` object to include the entire `CustomField` object, replacing the previous inclusion of only the `refId`. With this enhancement, access to additional `CustomField` properties such as `entityType` becomes available. This adjustment is necessary to properly implement `RecordService.deleteMissedOptionValues(...)` when managing custom fields for multiple `entityType`s.

See https://folio-org.atlassian.net/browse/FCFIELDS-48