### PR TITLE
[FCFIELDS-49] Implement getMessage for CustomFieldValidationException

### DIFF
--- a/src/main/java/org/folio/validate/CustomFieldValidationException.java
+++ b/src/main/java/org/folio/validate/CustomFieldValidationException.java
@@ -1,5 +1,6 @@
 package org.folio.validate;
 
+import io.vertx.core.json.Json;
 import org.folio.rest.jaxrs.model.Errors;
 
 public class CustomFieldValidationException extends RuntimeException {
@@ -8,6 +9,11 @@ public class CustomFieldValidationException extends RuntimeException {
 
   public CustomFieldValidationException(Errors errors) {
     this.errors = errors;
+  }
+
+  @Override
+  public String getMessage() {
+    return Json.encode(errors.getErrors());
   }
 
   public Errors getErrors() {

--- a/src/test/java/org/folio/validate/CustomFieldValidationExceptionTest.java
+++ b/src/test/java/org/folio/validate/CustomFieldValidationExceptionTest.java
@@ -1,0 +1,30 @@
+package org.folio.validate;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.junit.Test;
+
+public class CustomFieldValidationExceptionTest {
+
+  @Test
+  public void testGetMessage() {
+    Error error = new Error().withMessage("Test error message");
+    Errors errors = new Errors().withErrors(singletonList(error));
+    CustomFieldValidationException exception = new CustomFieldValidationException(errors);
+
+    String expectedMessage = "[{\"message\":\"Test error message\",\"parameters\":[]}]";
+    assertEquals(expectedMessage, exception.getMessage());
+  }
+
+  @Test
+  public void testGetErrors() {
+    Error error = new Error().withMessage("Test error message");
+    Errors errors = new Errors().withErrors(singletonList(error));
+    CustomFieldValidationException exception = new CustomFieldValidationException(errors);
+
+    assertEquals(errors, exception.getErrors());
+  }
+}


### PR DESCRIPTION
## Purpose
This PR enhances the `CustomFieldValidationException` class by implementing the `getMessage()` method. This improvement ensures that a helpful message is printed when logging instances of the exception.

See https://folio-org.atlassian.net/browse/FCFIELDS-49