### PR TITLE
[FCFIELDS-52] - Update JSONB operators used in RecordServiceImpl

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,18 @@ To use the `RecordServiceImpl`, follow these steps:
       }
     }
     ```
-
 2. Make the implementation available by updating the `META-INF/services/org.folio.service.
    RecordServiceFactory` file to contain the fully qualified name of the implementation class
   
     ```
     org.folio.services.record.RecordServiceFactoryImpl
     ```
-
+3. Optional. For efficient data handling, add a GIN index on the `jsonb->'customFields'`
+   expression to each entity table.
+    ```sql
+    CREATE INDEX purchase_order_customfields_recordservice_idx_gin
+    ON ${myuniversity}_${mymodule}.purchase_order USING GIN ((jsonb->'customFields'));
+    ```
 If neither of the above implementations are suitable, the steps above can also be followed to use a 
 different implementation.
 

--- a/src/test/java/org/folio/service/RecordServiceImplTest.java
+++ b/src/test/java/org/folio/service/RecordServiceImplTest.java
@@ -471,7 +471,10 @@ public class RecordServiceImplTest {
     SpringContextUtil.init(vertx, getFirstContextFromDeployments(), TestConfigSingleTable.class);
     CustomFieldOptionStatistic customFieldOptionStatistic =
       getCustomFieldOptionStatistic(customFieldsType1.get(1), "opt_1");
+    CustomFieldOptionStatistic customFieldOptionStatistic2 =
+      getCustomFieldOptionStatistic(customFieldsType1.get(2), "opt_2");
     assertThat(customFieldOptionStatistic.getCount()).isEqualTo(1);
+    assertThat(customFieldOptionStatistic2.getCount()).isEqualTo(2);
   }
 
   @Test
@@ -479,7 +482,10 @@ public class RecordServiceImplTest {
     SpringContextUtil.init(vertx, getFirstContextFromDeployments(), TestConfigMultiTable.class);
     CustomFieldOptionStatistic customFieldOptionStatistic =
       getCustomFieldOptionStatistic(customFieldsType1.get(1), "opt_1");
+    CustomFieldOptionStatistic customFieldOptionStatistic2 =
+      getCustomFieldOptionStatistic(customFieldsType1.get(2), "opt_2");
     assertThat(customFieldOptionStatistic.getCount()).isEqualTo(2);
+    assertThat(customFieldOptionStatistic2.getCount()).isEqualTo(3);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
As an addition to [PR#47](https://github.com/folio-org/folio-custom-fields/pull/47), this pull request modifies the JSONB operators used in `RecordServiceImpl` to ensure coverage by a GIN jsonb_ops index. Additionally, instructions have been added to the README detailing how to set up such an index.